### PR TITLE
Fix get_project_insight parameter parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ async function makeDovetailRequest(endpoint: string) {
         Authorization: `Bearer ${DOVETAIL_API_TOKEN}`,
       },
     });
-
+    
     if (!response.ok) {
       throw new Error(`Dovetail API error: ${response.status} ${response.statusText}`);
     }
@@ -89,7 +89,7 @@ server.tool(
   "get_project_insight",
   "Get a specific insight by ID",
   {
-    insight_id: { type: "string", description: "The ID of the insight to retrieve" },
+    insight_id: z.string().describe("The ID of the insight to retrieve"),
   },
   async ({ insight_id }) => {
     const data = await makeDovetailRequest(`/insights/${insight_id}`);


### PR DESCRIPTION
The get_project_insight tool was using a plain object schema format ({ type: "string", ... }) instead of a zod schema, causing the insight_id parameter to be parsed as undefined.

Updated to use z.string().describe(...) to match the other tool definitions.