### PR TITLE
Add get_insight_content tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,18 @@ server.tool(
 );
 
 server.tool(
+  "get_insight_content",
+  "Get insight content in markdown format",
+  {
+    insight_id: z.string().describe("The ID of the insight to retrieve"),
+  },
+  async ({ insight_id }) => {
+    const data = await makeDovetailRequest(`/insights/${insight_id}/export/markdown`);
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  },
+);
+
+server.tool(
   "list_project_insights",
   "List insights for a specific project",
   {


### PR DESCRIPTION
## Summary

- Adds a new `get_insight_content` MCP tool that retrieves insight content in markdown format
- The tool calls the `/insights/{insight_id}/export/markdown` endpoint, mirroring the existing `get_data_content` pattern
